### PR TITLE
Ignore lifecycle rules.

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Creates a CodePipeline for a project. The pipeline it creates has the following 
 ## Usage
 ```hcl
 module "codepipeline" {
-  source = "git@github.com:byu-oit/terraform-aws-codepipeline?ref=v1.1.1"
+  source = "git@github.com:byu-oit/terraform-aws-codepipeline?ref=v1.1.2"
 }
 ```
 

--- a/examples/example.tf
+++ b/examples/example.tf
@@ -19,4 +19,10 @@ module "codepipeline" {
 
 resource "aws_s3_bucket" "test" {
   bucket = "test-bucket-${data.aws_caller_identity.current.account_id}"
+
+  lifecycle {
+    ignore_changes = [
+      lifecycle_rule
+    ]
+  }
 }

--- a/main.tf
+++ b/main.tf
@@ -141,6 +141,12 @@ resource "aws_s3_bucket" "codebuild_bucket" {
       }
     }
   }
+
+  lifecycle {
+    ignore_changes = [
+      lifecycle_rule
+    ]
+  }
 }
 
 resource "aws_codebuild_project" "build-project" {


### PR DESCRIPTION
With Terraform, it will always try to recreate the lifecycle rules of an S3 bucket every time the user does `terraform apply`. We don't need these to change once set, so this ignores Terraform trying to recreate those rules.